### PR TITLE
Update line colors to match mocks

### DIFF
--- a/app/src/main/java/com/application/bikestreets/MainActivity.kt
+++ b/app/src/main/java/com/application/bikestreets/MainActivity.kt
@@ -27,6 +27,7 @@ import android.widget.ImageView
 import android.widget.TextView
 
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.mapbox.android.core.permissions.PermissionsListener
 import com.mapbox.android.core.permissions.PermissionsManager
 import com.mapbox.mapboxsdk.Mapbox
@@ -206,16 +207,19 @@ class MainActivity : AppCompatActivity() {
         // This is lazy coupling and will break, but I want to see it work as a proof-of-concept.
         // A more flexible refactor involves inspecting the GeoJson file itself to get the layer
         // name, then matching the color based on that (or we can save the layer color as metadata.)
-        val hexColor = when(layerName) {
-            "terms_of_use.txt" -> "#0000FF"
-            "3-bikelanes-master-v0.3.geojson" -> "#000000"
-            "5-walk-master-v0.3.geojson" -> "#FF0000"
-            "2-trails-master-v0.3.geojson" -> "#008000"
-            "4-bikesidewalks-master-v0.3.geojson" -> "#FF0000"
-            else -> "#000000"
+        val lineColor = when(layerName) {
+            "terms_of_use.txt" -> R.color.mapTrails
+            "1-bikestreets-master-v0.3.geojson" -> R.color.mapBikeStreets
+            "2-trails-master-v0.3.geojson" -> R.color.mapTrails
+            "3-bikelanes-master-v0.3.geojson" -> R.color.mapBikeLane
+            "4-bikesidewalks-master-v0.3.geojson" -> R.color.mapRideSidewalk
+            "5-walk-master-v0.3.geojson" -> R.color.mapWalkSidewalk
+            else -> R.color.mapDefault
         }
 
-        return Color.parseColor(hexColor)
+        // convert line color from R.color format to a more standard color format that
+        // PropertyFactory.lineColor knows how to work with
+        return ContextCompat.getColor(this, lineColor)
     }
 
     private fun createLineLayer(layerName: String): LineLayer {

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,4 +3,12 @@
     <color name="colorPrimary">#008577</color>
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
+
+    <!-- Colors for the Map Overlay -->
+    <color name="mapDefault">#000000</color>
+    <color name="mapTrails">#7a8a47</color>
+    <color name="mapBikeLane">#58595b</color>
+    <color name="mapBikeStreets">#345aa8</color>
+    <color name="mapRideSidewalk">#e82e8b</color>
+    <color name="mapWalkSidewalk">#d8282c</color>
 </resources>


### PR DESCRIPTION
# Description
Updates map route line colors. **See [the Trello card](https://trello.com/c/B1RdJeJT/99-update-route-line-color-palette?menu=filter&filter=label:Android) for details.**

# Implementation Notes
For the sake of better organization, I added these colors to colors.xml
and then accessed them using R.color. Following this convention will
allow us to keep all of our color definitions in one place for easier
updates.