### PR TITLE
Add text-offset to make road names appear above roads

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -12,7 +14,6 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/assets/stylejson/style.json
+++ b/app/src/main/assets/stylejson/style.json
@@ -2909,7 +2909,8 @@
                 "text-rotation-alignment": "map",
                 "text-pitch-alignment": "viewport",
                 "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
-                "text-letter-spacing": 0.01
+                "text-letter-spacing": 0.01,
+                "text-offset": [0, -1]
             },
             "paint": {
                 "text-color": "hsl(185, 3%, 47%)",

--- a/app/src/main/assets/stylejson/style.json
+++ b/app/src/main/assets/stylejson/style.json
@@ -2910,7 +2910,19 @@
                 "text-pitch-alignment": "viewport",
                 "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
                 "text-letter-spacing": 0.01,
-                "text-offset": [0, -1]
+                "text-offset": [
+                    "interpolate",
+                    ["linear"],
+                    ["zoom"],
+                    11,
+                    ["literal", [0, -0.5]],
+                    13,
+                    ["literal", [0, -1]],
+                    17,
+                    ["literal", [0, -1.5]],
+                    22,
+                    ["literal", [0, -1.7]]
+                ]
             },
             "paint": {
                 "text-color": "hsl(185, 3%, 47%)",

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Dec 14 20:59:13 MST 2019
+#Thu Apr 30 15:50:30 MDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
First pass at adjusting street names to appear above the actual street. Only actual modification is on file `app/src/main/assets/stylejson/style.json` with the addition of `"text-offset"

A basic, universal offset would look like
```
"text-offset": [0, -1]
```

In this case, I've changed the offset based on the zoom level after playing around in both Mapbox Studio and the emulator. This way, as the streets appear larger, the street name still appears outside of the street.
```
"text-offset": [
                    "interpolate",
                    ["linear"],
                    ["zoom"],
                    11,
                    ["literal", [0, -0.5]],
                    13,
                    ["literal", [0, -1]],
                    17,
                    ["literal", [0, -1.5]],
                    22,
                    ["literal", [0, -1.7]]
                ]
```
![Screenshot_1588368726](https://user-images.githubusercontent.com/26877629/80843276-1ece3180-8bc1-11ea-8571-dda45c9410ec.png)

Potential issues:
- Streets with medians like Colfax and Speer sometimes have the text pushed into another lane. 
- It's not very predictable if the street name will be pushed above or below it's anchor as it appears on the map. In Studio I've seen parallel streets with one label above and one below. 

Trello Card: [Street names should be above route lines](https://trello.com/c/22xuZFS9)