### PR TITLE
Add text offset based on zoom for road-label

### DIFF
--- a/app/src/main/assets/stylejson/style.json
+++ b/app/src/main/assets/stylejson/style.json
@@ -2909,7 +2909,20 @@
                 "text-rotation-alignment": "map",
                 "text-pitch-alignment": "viewport",
                 "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
-                "text-letter-spacing": 0.01
+                "text-letter-spacing": 0.01,
+                "text-offset": [
+                    "interpolate",
+                    ["linear"],
+                    ["zoom"],
+                    11,
+                    ["literal", [0, -0.5]],
+                    13,
+                    ["literal", [0, -1]],
+                    17,
+                    ["literal", [0, -1.5]],
+                    22,
+                    ["literal", [0, -1.7]]
+                ]
             },
             "paint": {
                 "text-color": "hsl(185, 3%, 47%)",


### PR DESCRIPTION
Cleaned up from closed PR #11 with only the changes to `style.json`
<hr>
Adjusting street names to appear above the actual street on file `app/src/main/assets/stylejson/style.json` with the addition of `"text-offset"

A basic, universal offset would look like
```
"text-offset": [0, -1]
```

In this case, I've changed the offset based on the zoom level after playing around in both Mapbox Studio and the emulator. This way, as the streets appear larger, the street name still appears outside of the street.
```
"text-offset": [
                    "interpolate",
                    ["linear"],
                    ["zoom"],
                    11,
                    ["literal", [0, -0.5]],
                    13,
                    ["literal", [0, -1]],
                    17,
                    ["literal", [0, -1.5]],
                    22,
                    ["literal", [0, -1.7]]
                ]
```
![Screenshot_1588368726](https://user-images.githubusercontent.com/26877629/80843276-1ece3180-8bc1-11ea-8571-dda45c9410ec.png)

Potential issues:
- Streets with medians like Colfax and Speer sometimes have the text pushed into another lane. 
- It's not very predictable if the street name will be pushed above or below it's anchor as it appears on the map. In Studio I've seen parallel streets with one label above and one below. 

Trello Card: [Street names should be above route lines](https://trello.com/c/22xuZFS9)