### PR TITLE
Insert GeoJSON bikestreets layer below road-labels

### DIFF
--- a/app/src/main/assets/stylejson/style.json
+++ b/app/src/main/assets/stylejson/style.json
@@ -2864,7 +2864,7 @@
                             "secondary",
                             "tertiary"
                         ],
-                        10,
+                        14,
                         [
                             "motorway_link",
                             "trunk_link",
@@ -2874,8 +2874,8 @@
                             "street",
                             "street_limited"
                         ],
-                        9,
-                        6.5
+                        12,
+                        10
                     ],
                     18,
                     [
@@ -2899,7 +2899,7 @@
                             "street_limited"
                         ],
                         14,
-                        13
+                        14
                     ]
                 ],
                 "text-max-angle": 30,
@@ -2909,20 +2909,7 @@
                 "text-rotation-alignment": "map",
                 "text-pitch-alignment": "viewport",
                 "text-field": ["coalesce", ["get", "name_en"], ["get", "name"]],
-                "text-letter-spacing": 0.01,
-                "text-offset": [
-                    "interpolate",
-                    ["linear"],
-                    ["zoom"],
-                    11,
-                    ["literal", [0, -0.5]],
-                    13,
-                    ["literal", [0, -1]],
-                    17,
-                    ["literal", [0, -1.5]],
-                    22,
-                    ["literal", [0, -1.7]]
-                ]
+                "text-letter-spacing": 0.01
             },
             "paint": {
                 "text-color": "hsl(185, 3%, 47%)",

--- a/app/src/main/java/com/application/bikestreets/MainActivity.kt
+++ b/app/src/main/java/com/application/bikestreets/MainActivity.kt
@@ -226,7 +226,7 @@ class MainActivity : AppCompatActivity() {
             mapStyle.addSource(GeoJsonSource(layerName, featureCollection))
 
             // create a line layer that reads the GeoJSON data that we just added
-            mapStyle.addLayer(createLineLayer(layerName))
+            mapStyle.addLayerBelow(createLineLayer(layerName), "road-label")
         }
     }
 


### PR DESCRIPTION
Road labels are now above/layered on top of the bikestreets route layer. The key change is changing `addLayer` to `addLayerBelow` in the `renderFeatureCollection` function in `MainActivity.kt`. 

In order to see the road-label are in fact on top of the bikestreets layer, the y-offsets were deleted and font-size bumped up in `style.json`. I'll make a PR to the shared style.json file in [denver-map](https://github.com/bikestreets/denver-map) for iOS to use too.

Per Mark's comment on Trello, if we want to keep `addLayer` in case the `road-label` layer gets renamed by Mapbox in the future, we could create a local variable for the `road-label` layer and the use a conditional to render with either `addLayer` or `addLayerBelow`. I'm not sure if this is a necessary precaution as our layers are also defined in our `style.json` file.

Trello Card: https://trello.com/c/22xuZFS9/107-street-names-should-be-above-route-lines

Mapbox documentation: 
- https://docs.mapbox.com/android/maps/examples/add-a-new-layer-below-labels/
- https://docs.mapbox.com/android/maps/overview/styling-map/#retrieving-a-map-layer

![Screenshot_1589490796](https://user-images.githubusercontent.com/26877629/81988654-70cf7800-9601-11ea-93e7-c181b677e161.png)