### PR TITLE
Increase size and halo width for road-labels

### DIFF
--- a/app/src/main/assets/stylejson/style.json
+++ b/app/src/main/assets/stylejson/style.json
@@ -2864,7 +2864,7 @@
                             "secondary",
                             "tertiary"
                         ],
-                        14,
+                        18,
                         [
                             "motorway_link",
                             "trunk_link",
@@ -2874,8 +2874,8 @@
                             "street",
                             "street_limited"
                         ],
-                        12,
-                        10
+                        16,
+                        14
                     ],
                     18,
                     [
@@ -2888,7 +2888,7 @@
                             "secondary",
                             "tertiary"
                         ],
-                        16,
+                        26,
                         [
                             "motorway_link",
                             "trunk_link",
@@ -2898,8 +2898,8 @@
                             "street",
                             "street_limited"
                         ],
-                        14,
-                        14
+                        22,
+                        18
                     ]
                 ],
                 "text-max-angle": 30,
@@ -2914,8 +2914,8 @@
             "paint": {
                 "text-color": "hsl(185, 3%, 47%)",
                 "text-halo-color": "hsl(185, 1%, 100%)",
-                "text-halo-width": 1,
-                "text-halo-blur": 1
+                "text-halo-width": 3,
+                "text-halo-blur": 0
             }
         },
         {


### PR DESCRIPTION
What: Update to the style.json file for increased road-label text size and a larger, no-blur halo around the letters. After pairing with Avi to confirm styling, these are the style changes.

Why: To increase readability of the road-labels on the map for _more experienced_ eyes and outdoor use.

Trello Card: https://trello.com/c/ewPt2oXb